### PR TITLE
Fixed path on transcoder.info method.

### DIFF
--- a/wowza/wowza.py
+++ b/wowza/wowza.py
@@ -811,7 +811,7 @@ class Transcoders(object):
                     'message': 'Option provided is invalid. Valid options are: {}'\
                         .format(valid_options)
                 })
-            path = path + option
+            path = path + "/" + option
         response = session.get(path, headers=self.headers)
         return response.json()
 


### PR DESCRIPTION
Na chamada ficava transcoders/{id}recordings em vez de transcoders/{id}/recordings